### PR TITLE
Rename `module_start` to `plugin_load`

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -244,10 +244,6 @@ export GOLDHEN_SDK=[directory of installation]
 ```
 3. Run `make` in the root of the repository or `make` individually; built binaries can be found in `bin/plugins`.
 
-# Troubleshooting log crashes
-
-If you ran into crashes related to print logging (usually during VA args assignment clearing stack) you can try building with printf `make LOG=PRINTF`.
-
 <!-- Win32 build script not up to date-->
 ### Windows
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -82,11 +82,11 @@ jobs:
       working-directory: SDK
       run: echo "GOLDHEN_SDK=$(pwd)" >> $GITHUB_ENV
 
-    - name: Build (Release) (printf)
-      run: make LOG=PRINTF
+    - name: Build (Release)
+      run: make
 
-    - name: Build (Debug) (printf)
-      run: make LOG=PRINTF DEBUG=1
+    - name: Build (Debug)
+      run: make DEBUG=1
 
     - name: Push module artifact (Release prx)
       uses: actions/upload-artifact@v3

--- a/Makefile
+++ b/Makefile
@@ -9,13 +9,8 @@ else
 	DEBUG_FLAG=DEBUG=0
 endif
 
-ifeq ($(LOG), PRINTF)
-	LOG_TYPE=PRINTF=1
-	LOG_MSG=libc:printf
-else
-	LOG_TYPE=
-	LOG_MSG=GoldHEN:SDK:KernelLog
-endif
+LOG_TYPE=PRINTF=1
+LOG_MSG=libc:printf
 
 all: build hashes
 

--- a/plugin_src/afr/Makefile
+++ b/plugin_src/afr/Makefile
@@ -1,12 +1,8 @@
 # Library metadata.
 
 DEBUG_FLAGS = -D__FINAL__=1
-LOG_TYPE = -D__USE_KLOG__
+LOG_TYPE = -D__USE_PRINTF__
 BUILD_TYPE = _final
-
-ifeq ($(PRINTF),1)
-    LOG_TYPE = -D__USE_PRINTF__
-endif
 
 ifeq ($(DEBUG),1)
     DEBUG_FLAGS = -D__FINAL__=0
@@ -22,7 +18,7 @@ TARGET_ELF   := $(BUILD_FOLDER)/elf$(TYPE)/$(OUTPUT_PRX)
 TARGETSTUB   := $(OUTPUT_PRX).so
 
 # Libraries linked into the ELF.
-LIBS := -lGoldHEN_Hook -lkernel -lSceLibcInternal -lSceSysmodule
+LIBS := -lSceLibcInternal -lGoldHEN_Hook -lkernel -lSceSysmodule
 
 EXTRAFLAGS := $(DEBUG_FLAGS) $(LOG_TYPE) -fcolor-diagnostics -Wall
 

--- a/plugin_src/afr/source/main.c
+++ b/plugin_src/afr/source/main.c
@@ -102,7 +102,7 @@ s32 sceKernelOpen_hook(const char *path, s32 flags, OrbisKernelMode mode)
     return fd;
 }
 
-s32 attr_module_hidden module_start(s64 argc, const void *args)
+s32 attr_public plugin_load(s32 argc, const char* argv[])
 {
     final_printf("[GoldHEN] <%s\\Ver.0x%08x> %s\n", g_pluginName, g_pluginVersion, __func__);
     final_printf("[GoldHEN] Plugin Author(s): %s\n", g_pluginAuth);
@@ -118,11 +118,21 @@ s32 attr_module_hidden module_start(s64 argc, const void *args)
     return 0;
 }
 
-s32 attr_module_hidden module_stop(s64 argc, const void *args)
+s32 attr_public plugin_unload(s32 argc, const char* argv[])
 {
     final_printf("[GoldHEN] <%s\\Ver.0x%08x> %s\n", g_pluginName, g_pluginVersion, __func__);
     UNHOOK(sceKernelOpen);
     UNHOOK(sceKernelStat);
     UNHOOK(fopen);
+    return 0;
+}
+
+s32 attr_module_hidden module_start(s64 argc, const void *args)
+{
+    return 0;
+}
+
+s32 attr_module_hidden module_stop(s64 argc, const void *args)
+{
     return 0;
 }

--- a/plugin_src/aio_fix_505/Makefile
+++ b/plugin_src/aio_fix_505/Makefile
@@ -1,12 +1,8 @@
 # Library metadata.
 
 DEBUG_FLAGS = -D__FINAL__=1
-LOG_TYPE = -D__USE_KLOG__
+LOG_TYPE = -D__USE_PRINTF__
 BUILD_TYPE = _final
-
-ifeq ($(PRINTF),1)
-    LOG_TYPE = -D__USE_PRINTF__
-endif
 
 ifeq ($(DEBUG),1)
     DEBUG_FLAGS = -D__FINAL__=0
@@ -22,7 +18,7 @@ TARGET_ELF   := $(BUILD_FOLDER)/elf$(TYPE)/$(OUTPUT_PRX)
 TARGETSTUB   := $(OUTPUT_PRX).so
 
 # Libraries linked into the ELF.
-LIBS := -lGoldHEN_Hook -lkernel -lSceLibcInternal -lSceSysmodule
+LIBS := -lSceLibcInternal -lGoldHEN_Hook -lkernel -lSceSysmodule
 
 EXTRAFLAGS := $(DEBUG_FLAGS) $(LOG_TYPE) -fcolor-diagnostics -Wall
 

--- a/plugin_src/aio_fix_505/source/main.c
+++ b/plugin_src/aio_fix_505/source/main.c
@@ -307,7 +307,7 @@ s32 sceKernelAioSubmitWriteCommandsMultiple_hook(SceKernelAioRWRequest req[], s3
     return 0;
 }
 
-s32 attr_module_hidden module_start(s64 argc, const void* args) {
+s32 attr_public plugin_load(s32 argc, const char* argv[]) {
     final_printf("[GoldHEN] <%s\\Ver.0x%08x> %s\n", g_pluginName, g_pluginVersion, __func__);
     final_printf("[GoldHEN] Plugin Author(s): %s\n", g_pluginAuth);
     boot_ver();
@@ -353,7 +353,7 @@ s32 attr_module_hidden module_start(s64 argc, const void* args) {
     return 0;
 }
 
-s32 attr_module_hidden module_stop(s64 argc, const void* args) {
+s32 attr_public plugin_unload(s32 argc, const char* argv[]) {
     final_printf("[GoldHEN] <%s\\Ver.0x%08x> %s\n", g_pluginName, g_pluginVersion, __func__);
     UNHOOK(sceKernelAioInitializeImpl);
     UNHOOK(sceKernelAioDeleteRequest);
@@ -368,5 +368,15 @@ s32 attr_module_hidden module_stop(s64 argc, const void* args) {
     UNHOOK(sceKernelAioSubmitReadCommandsMultiple);
     UNHOOK(sceKernelAioSubmitWriteCommands);
     UNHOOK(sceKernelAioSubmitWriteCommandsMultiple);
+    return 0;
+}
+
+s32 attr_module_hidden module_start(s64 argc, const void *args)
+{
+    return 0;
+}
+
+s32 attr_module_hidden module_stop(s64 argc, const void *args)
+{
     return 0;
 }

--- a/plugin_src/button_swap/Makefile
+++ b/plugin_src/button_swap/Makefile
@@ -1,12 +1,8 @@
 # Library metadata.
 
 DEBUG_FLAGS = -D__FINAL__=1
-LOG_TYPE = -D__USE_KLOG__
+LOG_TYPE = -D__USE_PRINTF__
 BUILD_TYPE = _final
-
-ifeq ($(PRINTF),1)
-    LOG_TYPE = -D__USE_PRINTF__
-endif
 
 ifeq ($(DEBUG),1)
     DEBUG_FLAGS = -D__FINAL__=0
@@ -22,7 +18,7 @@ TARGET_ELF   := $(BUILD_FOLDER)/elf$(TYPE)/$(OUTPUT_PRX)
 TARGETSTUB   := $(OUTPUT_PRX).so
 
 # Libraries linked into the ELF.
-LIBS := -lGoldHEN_Hook -lkernel -lSceLibcInternal -lSceSysmodule -lSceSystemService
+LIBS := -lSceLibcInternal -lGoldHEN_Hook -lkernel -lSceSysmodule -lSceSystemService
 
 EXTRAFLAGS := $(DEBUG_FLAGS) $(LOG_TYPE) -fcolor-diagnostics -Wall
 

--- a/plugin_src/button_swap/source/main.c
+++ b/plugin_src/button_swap/source/main.c
@@ -23,7 +23,7 @@ s32 sceSystemServiceParamGetInt_hook(s32 paramId, s32 *value) {
     return ret;
 }
 
-s32 attr_module_hidden module_start(s64 argc, const void *args) {
+s32 attr_public plugin_load(s32 argc, const char* argv[]) {
     final_printf("[GoldHEN] <%s\\Ver.0x%08x> %s\n", g_pluginName, g_pluginVersion, __func__);
     final_printf("[GoldHEN] Plugin Author(s): %s\n", g_pluginAuth);
     boot_ver();
@@ -34,8 +34,18 @@ s32 attr_module_hidden module_start(s64 argc, const void *args) {
     return 0;
 }
 
-s32 attr_module_hidden module_stop(s64 argc, const void *args) {
+s32 attr_public plugin_unload(s32 argc, const char* argv[]) {
     final_printf("[GoldHEN] <%s\\Ver.0x%08x> %s\n", g_pluginName, g_pluginVersion, __func__);
     UNHOOK(sceSystemServiceParamGetInt);
+    return 0;
+}
+
+s32 attr_module_hidden module_start(s64 argc, const void *args)
+{
+    return 0;
+}
+
+s32 attr_module_hidden module_stop(s64 argc, const void *args)
+{
     return 0;
 }

--- a/plugin_src/fliprate_remover/Makefile
+++ b/plugin_src/fliprate_remover/Makefile
@@ -1,12 +1,8 @@
 # Library metadata.
 
 DEBUG_FLAGS = -D__FINAL__=1
-LOG_TYPE = -D__USE_KLOG__
+LOG_TYPE = -D__USE_PRINTF__
 BUILD_TYPE = _final
-
-ifeq ($(PRINTF),1)
-    LOG_TYPE = -D__USE_PRINTF__
-endif
 
 ifeq ($(DEBUG),1)
     DEBUG_FLAGS = -D__FINAL__=0
@@ -22,7 +18,7 @@ TARGET_ELF   := $(BUILD_FOLDER)/elf$(TYPE)/$(OUTPUT_PRX)
 TARGETSTUB   := $(OUTPUT_PRX).so
 
 # Libraries linked into the ELF.
-LIBS := -lSceVideoOut -lGoldHEN_Hook -lkernel -lSceLibcInternal -lSceSysmodule
+LIBS := -lSceLibcInternal -lSceVideoOut -lGoldHEN_Hook -lkernel -lSceSysmodule
 
 EXTRAFLAGS := $(DEBUG_FLAGS) $(LOG_TYPE) -fcolor-diagnostics -Wall
 

--- a/plugin_src/fliprate_remover/source/main.c
+++ b/plugin_src/fliprate_remover/source/main.c
@@ -20,7 +20,7 @@ s32 sceVideoOutSetFlipRate_hook(s32 handle, s32 fliprate){
     return 0;
 }
 
-s32 attr_module_hidden module_start(s64 argc, const void *args) {
+s32 attr_public plugin_load(s32 argc, const char* argv[]) {
     final_printf("[GoldHEN] <%s\\Ver.0x%08x> %s\n", g_pluginName, g_pluginVersion, __func__);
     final_printf("[GoldHEN] Plugin Author(s): %s\n", g_pluginAuth);
     boot_ver();
@@ -28,8 +28,18 @@ s32 attr_module_hidden module_start(s64 argc, const void *args) {
     return 0;
 }
 
-s32 attr_module_hidden module_stop(s64 argc, const void *args) {
+s32 attr_public plugin_unload(s32 argc, const char* argv[]) {
     final_printf("[GoldHEN] <%s\\Ver.0x%08x> %s\n", g_pluginName, g_pluginVersion, __func__);
     UNHOOK(sceVideoOutSetFlipRate);
+    return 0;
+}
+
+s32 attr_module_hidden module_start(s64 argc, const void *args)
+{
+    return 0;
+}
+
+s32 attr_module_hidden module_stop(s64 argc, const void *args)
+{
     return 0;
 }

--- a/plugin_src/force_1080p_display/Makefile
+++ b/plugin_src/force_1080p_display/Makefile
@@ -1,12 +1,8 @@
 # Library metadata.
 
 DEBUG_FLAGS = -D__FINAL__=1
-LOG_TYPE = -D__USE_KLOG__
+LOG_TYPE = -D__USE_PRINTF__
 BUILD_TYPE = _final
-
-ifeq ($(PRINTF),1)
-    LOG_TYPE = -D__USE_PRINTF__
-endif
 
 ifeq ($(DEBUG),1)
     DEBUG_FLAGS = -D__FINAL__=0
@@ -22,7 +18,7 @@ TARGET_ELF   := $(BUILD_FOLDER)/elf$(TYPE)/$(OUTPUT_PRX)
 TARGETSTUB   := $(OUTPUT_PRX).so
 
 # Libraries linked into the ELF.
-LIBS := -lSceVideoOut -lGoldHEN_Hook -lkernel -lSceLibcInternal -lSceSysmodule
+LIBS := -lSceLibcInternal -lSceVideoOut -lGoldHEN_Hook -lkernel -lSceSysmodule
 
 EXTRAFLAGS := $(DEBUG_FLAGS) $(LOG_TYPE) -fcolor-diagnostics -Wall
 

--- a/plugin_src/force_1080p_display/source/main.c
+++ b/plugin_src/force_1080p_display/source/main.c
@@ -45,7 +45,7 @@ s32 sceVideoOutGetResolutionStatus_hook(int handle, OrbisVideoOutResolutionStatu
     return ret;
 }
 
-s32 attr_module_hidden module_start(s64 argc, const void *args) {
+s32 attr_public plugin_load(s32 argc, const char* argv[]) {
     final_printf("[GoldHEN] <%s\\Ver.0x%08x> %s\n", g_pluginName, g_pluginVersion, __func__);
     final_printf("[GoldHEN] Plugin Author(s): %s\n", g_pluginAuth);
     boot_ver();
@@ -53,8 +53,18 @@ s32 attr_module_hidden module_start(s64 argc, const void *args) {
     return 0;
 }
 
-s32 attr_module_hidden module_stop(s64 argc, const void *args) {
+s32 attr_public plugin_unload(s32 argc, const char* argv[]) {
     final_printf("[GoldHEN] <%s\\Ver.0x%08x> %s\n", g_pluginName, g_pluginVersion, __func__);
     UNHOOK(sceVideoOutGetResolutionStatus);
+    return 0;
+}
+
+s32 attr_module_hidden module_start(s64 argc, const void *args)
+{
+    return 0;
+}
+
+s32 attr_module_hidden module_stop(s64 argc, const void *args)
+{
     return 0;
 }

--- a/plugin_src/force_30_fps/Makefile
+++ b/plugin_src/force_30_fps/Makefile
@@ -1,12 +1,8 @@
 # Library metadata.
 
 DEBUG_FLAGS = -D__FINAL__=1
-LOG_TYPE = -D__USE_KLOG__
+LOG_TYPE = -D__USE_PRINTF__
 BUILD_TYPE = _final
-
-ifeq ($(PRINTF),1)
-    LOG_TYPE = -D__USE_PRINTF__
-endif
 
 ifeq ($(DEBUG),1)
     DEBUG_FLAGS = -D__FINAL__=0
@@ -22,7 +18,7 @@ TARGET_ELF   := $(BUILD_FOLDER)/elf$(TYPE)/$(OUTPUT_PRX)
 TARGETSTUB   := $(OUTPUT_PRX).so
 
 # Libraries linked into the ELF.
-LIBS := -lSceVideoOut -lGoldHEN_Hook -lkernel -lSceLibcInternal -lSceSysmodule
+LIBS := -lSceLibcInternal -lSceVideoOut -lGoldHEN_Hook -lkernel -lSceSysmodule
 
 EXTRAFLAGS := $(DEBUG_FLAGS) $(LOG_TYPE) -fcolor-diagnostics -Wall
 

--- a/plugin_src/force_30_fps/source/main.c
+++ b/plugin_src/force_30_fps/source/main.c
@@ -20,7 +20,7 @@ s32 sceVideoOutSetFlipRate_hook(s32 handle, s32 fliprate)
                         handle, 1);
 }
 
-s32 attr_module_hidden module_start(s64 argc, const void *args)
+s32 attr_public plugin_load(s32 argc, const char* argv[])
 {
     final_printf("[GoldHEN] <%s\\Ver.0x%08x> %s\n", g_pluginName, g_pluginVersion, __func__);
     final_printf("[GoldHEN] Plugin Author(s): %s\n", g_pluginAuth);
@@ -29,9 +29,19 @@ s32 attr_module_hidden module_start(s64 argc, const void *args)
     return 0;
 }
 
-s32 attr_module_hidden module_stop(s64 argc, const void *args)
+s32 attr_public plugin_unload(s32 argc, const char* argv[])
 {
     final_printf("[GoldHEN] <%s\\Ver.0x%08x> %s\n", g_pluginName, g_pluginVersion, __func__);
     UNHOOK(sceVideoOutSetFlipRate);
+    return 0;
+}
+
+s32 attr_module_hidden module_start(s64 argc, const void *args)
+{
+    return 0;
+}
+
+s32 attr_module_hidden module_stop(s64 argc, const void *args)
+{
     return 0;
 }

--- a/plugin_src/game_call_example/Makefile
+++ b/plugin_src/game_call_example/Makefile
@@ -1,12 +1,8 @@
 # Library metadata.
 
 DEBUG_FLAGS = -D__FINAL__=1
-LOG_TYPE = -D__USE_KLOG__
+LOG_TYPE = -D__USE_PRINTF__
 BUILD_TYPE = _final
-
-ifeq ($(PRINTF),1)
-    LOG_TYPE = -D__USE_PRINTF__
-endif
 
 ifeq ($(DEBUG),1)
     DEBUG_FLAGS = -D__FINAL__=0
@@ -22,7 +18,7 @@ TARGET_ELF   := $(BUILD_FOLDER)/elf$(TYPE)/$(OUTPUT_PRX)
 TARGETSTUB   := $(OUTPUT_PRX).so
 
 # Libraries linked into the ELF.
-LIBS := -lGoldHEN_Hook -lkernel -lSceLibcInternal -lSceSysmodule
+LIBS := -lSceLibcInternal -lGoldHEN_Hook -lkernel -lSceSysmodule
 
 EXTRAFLAGS := $(DEBUG_FLAGS) $(LOG_TYPE) -fcolor-diagnostics -Wall
 

--- a/plugin_src/game_call_example/source/main.c
+++ b/plugin_src/game_call_example/source/main.c
@@ -39,7 +39,7 @@ void* my_thread(void* args)
     return NULL;
 }
 
-int32_t attr_module_hidden module_start(size_t argc, const void *args)
+int32_t attr_public plugin_load(int32_t argc, const char* argv[])
 {
     if (sys_sdk_proc_info(&procInfo) == 0)
     {
@@ -58,9 +58,19 @@ int32_t attr_module_hidden module_start(size_t argc, const void *args)
     return 0;
 }
 
-int32_t attr_module_hidden module_stop(size_t argc, const void *args)
+int32_t attr_public plugin_unload(int32_t argc, const char* argv[])
 {
     final_printf("[GoldHEN] <%s\\Ver.0x%08x> %s\n", g_pluginName, g_pluginVersion, __func__);
     final_printf("[GoldHEN] %s Plugin Ended.\n", g_pluginName);
+    return 0;
+}
+
+s32 attr_module_hidden module_start(s64 argc, const void *args)
+{
+    return 0;
+}
+
+s32 attr_module_hidden module_stop(s64 argc, const void *args)
+{
     return 0;
 }

--- a/plugin_src/game_patch/Makefile
+++ b/plugin_src/game_patch/Makefile
@@ -1,12 +1,8 @@
 # Library metadata.
 
 DEBUG_FLAGS = -D__FINAL__=1
-LOG_TYPE = -D__USE_KLOG__
+LOG_TYPE = -D__USE_PRINTF__
 BUILD_TYPE = _final
-
-ifeq ($(PRINTF),1)
-    LOG_TYPE = -D__USE_PRINTF__
-endif
 
 ifeq ($(DEBUG),1)
     DEBUG_FLAGS = -D__FINAL__=0
@@ -22,7 +18,7 @@ TARGET_ELF   := $(BUILD_FOLDER)/elf$(TYPE)/$(OUTPUT_PRX)
 TARGETSTUB   := $(OUTPUT_PRX).so
 
 # Libraries linked into the ELF.
-LIBS := -lGoldHEN_Hook -lkernel -lSceLibcInternal -lSceSysmodule -lmxml
+LIBS := -lSceLibcInternal -lGoldHEN_Hook -lkernel -lSceSysmodule -lmxml
 
 EXTRAFLAGS := $(DEBUG_FLAGS) $(LOG_TYPE) -fcolor-diagnostics -Wall -D__PRX_BUILD__
 

--- a/plugin_src/game_patch/source/main.cpp
+++ b/plugin_src/game_patch/source/main.cpp
@@ -55,7 +55,8 @@ void get_key_init(void)
 
     if (res)
     {
-        final_printf("file %s not found\nerror: 0x%08x", input_file, res);
+        final_printf("file %s not found\n", input_file);
+        final_printf("error: 0x%08x\n", res);
         return;
     }
 
@@ -86,7 +87,7 @@ void get_key_init(void)
             debug_printf("AppElf: \"%s\"\n", AppElfData);
 
             u64 hashout = patch_hash_calc(TitleData, NameData, AppVerData, input_file, AppElfData);
-            char settings_path[MAX_PATH_];
+            char settings_path[MAX_PATH_] = {0};
             snprintf(settings_path, sizeof(settings_path), BASE_PATH_PATCH_SETTINGS "/0x%016lx.txt", hashout);
             final_printf("Settings path: %s\n", settings_path);
             s32 res = Read_File(settings_path, &buffer2, &size2, 0);
@@ -239,7 +240,7 @@ void make_folders(void)
 }
 
 extern "C" {
-s32 attr_module_hidden module_start(s64 argc, const void *args) {
+s32 attr_public plugin_load(s32 argc, const char* argv[]) {
     final_printf("[GoldHEN] <%s\\Ver.0x%08x> %s\n", g_pluginName, g_pluginVersion, __func__);
     final_printf("[GoldHEN] Plugin Author(s): %s\n", g_pluginAuth);
     boot_ver();
@@ -265,11 +266,19 @@ s32 attr_module_hidden module_start(s64 argc, const void *args) {
     NotifyStatic(TEX_ICON_SYSTEM, "Unable to get process info from sys_sdk_proc_info");
     return -1;
 }
+
+s32 attr_public plugin_unload(s32 argc, const char* argv[]) {
+    final_printf("[GoldHEN] <%s\\Ver.0x%08x> %s\n", g_pluginName, g_pluginVersion, __func__);
+    return 0;
 }
 
-extern "C" {
-s32 attr_module_hidden module_stop(s64 argc, const void *args) {
-    final_printf("[GoldHEN] <%s\\Ver.0x%08x> %s\n", g_pluginName, g_pluginVersion, __func__);
+s32 attr_module_hidden module_start(s64 argc, const void *args)
+{
+    return 0;
+}
+
+s32 attr_module_hidden module_stop(s64 argc, const void *args)
+{
     return 0;
 }
 }

--- a/plugin_src/game_patch/source/patch.cpp
+++ b/plugin_src/game_patch/source/patch.cpp
@@ -25,7 +25,7 @@ char* unescape(const char *s) {
                     break;
                 case 'x':
                     {
-                        char hex_string[3];
+                        char hex_string[3] = {0};
                         u32 val = 0;
                         hex_string[0] = s[++i];
                         hex_string[1] = s[++i];
@@ -134,7 +134,7 @@ constexpr u64 djb2_hash(const char *str) {
 u64 patch_hash_calc(const char *title, const char *name, const char *app_ver,
                     const char *title_id, const char *elf) {
     u64 output_hash = 0;
-    char hash_str[256];
+    char hash_str[256] = {0};
     snprintf(hash_str, sizeof(hash_str), "%s%s%s%s%s", title, name, app_ver,
              title_id, elf);
     output_hash = djb2_hash(hash_str);
@@ -273,7 +273,7 @@ void patch_data1(const char* patch_type_str, u64 addr, const char *value, uint32
                 sys_proc_rw(addr + i, nop_byte, sizeof(nop_byte));
             }
             u8 jump_32[] = { 0xe9, 0x00, 0x00, 0x00, 0x00 };
-            s32 target_jmp = (s32) (jump_target - addr - 5);
+            s32 target_jmp = (s32) (jump_target - addr - sizeof(jump_32));
             s32 target_return = (s32) (addr) - (code_cave_end);
             sys_proc_rw(jump_target, bytearray, bytearray_size);
             sys_proc_rw(addr, jump_32, sizeof(jump_32));

--- a/plugin_src/gamepad_helper/Makefile
+++ b/plugin_src/gamepad_helper/Makefile
@@ -4,10 +4,6 @@ DEBUG_FLAGS = -D__FINAL__=1
 LOG_TYPE = -D__USE_PRINTF__
 BUILD_TYPE = _final
 
-ifeq ($(PRINTF),1)
-    LOG_TYPE = -D__USE_PRINTF__
-endif
-
 ifeq ($(DEBUG),1)
     DEBUG_FLAGS = -D__FINAL__=0
     BUILD_TYPE = _debug
@@ -22,7 +18,7 @@ TARGET_ELF   := $(BUILD_FOLDER)/elf$(TYPE)/$(OUTPUT_PRX)
 TARGETSTUB   := $(OUTPUT_PRX).so
 
 # Libraries linked into the ELF.
-LIBS := -lGoldHEN_Hook -lkernel -lSceLibcInternal -lSceSysmodule -lScePad
+LIBS := -lSceLibcInternal -lGoldHEN_Hook -lkernel -lSceSysmodule -lScePad
 
 EXTRAFLAGS := $(DEBUG_FLAGS) $(LOG_TYPE) -fcolor-diagnostics -Wall
 

--- a/plugin_src/gamepad_helper/source/main.c
+++ b/plugin_src/gamepad_helper/source/main.c
@@ -209,7 +209,7 @@ int32_t load_config(ini_table_s* table, const char* section_name) {
     return 0;
 }
 
-s32 attr_module_hidden module_start(s64 argc, const void* args) {
+s32 attr_public plugin_load(s32 argc, const char* argv[]) {
     final_printf("[GoldHEN] <%s\\Ver.0x%08x> %s\n", g_pluginName, g_pluginVersion, __func__);
     final_printf("[GoldHEN] Plugin Author(s): %s\n", g_pluginAuth);
     boot_ver();
@@ -333,7 +333,7 @@ s32 attr_module_hidden module_start(s64 argc, const void* args) {
     return 0;
 }
 
-s32 attr_module_hidden module_stop(s64 argc, const void* args) {
+s32 attr_public plugin_unload(s32 argc, const char* argv[]) {
     final_printf("[GoldHEN] <%s\\Ver.0x%08x> %s\n", g_pluginName, g_pluginVersion, __func__);
     UNHOOK(scePadRead);
     UNHOOK(scePadReadState);
@@ -348,5 +348,15 @@ s32 attr_module_hidden module_stop(s64 argc, const void* args) {
     free(scePadReadStateExtPatcher);
     free(buttonMapping);
 
+    return 0;
+}
+
+s32 attr_module_hidden module_start(s64 argc, const void *args)
+{
+    return 0;
+}
+
+s32 attr_module_hidden module_stop(s64 argc, const void *args)
+{
     return 0;
 }

--- a/plugin_src/no_share_watermark/Makefile
+++ b/plugin_src/no_share_watermark/Makefile
@@ -1,12 +1,8 @@
 # Library metadata.
 
 DEBUG_FLAGS = -D__FINAL__=1
-LOG_TYPE = -D__USE_KLOG__
+LOG_TYPE = -D__USE_PRINTF__
 BUILD_TYPE = _final
-
-ifeq ($(PRINTF),1)
-    LOG_TYPE = -D__USE_PRINTF__
-endif
 
 ifeq ($(DEBUG),1)
     DEBUG_FLAGS = -D__FINAL__=0
@@ -22,7 +18,7 @@ TARGET_ELF   := $(BUILD_FOLDER)/elf$(TYPE)/$(OUTPUT_PRX)
 TARGETSTUB   := $(OUTPUT_PRX).so
 
 # Libraries linked into the ELF.
-LIBS := -lSceScreenShot -lSceVideoRecording -lSceRemoteplay -lGoldHEN_Hook -lkernel -lSceLibcInternal -lSceSysmodule
+LIBS := -lSceLibcInternal -lSceScreenShot -lSceVideoRecording -lSceRemoteplay -lGoldHEN_Hook -lkernel -lSceSysmodule
 
 EXTRAFLAGS := $(DEBUG_FLAGS) $(LOG_TYPE) -fcolor-diagnostics -Wall
 

--- a/plugin_src/no_share_watermark/source/main.c
+++ b/plugin_src/no_share_watermark/source/main.c
@@ -62,7 +62,7 @@ s32 sceScreenShotDisable_hook(void){
     return 0;
 }
 
-s32 attr_module_hidden module_start(s64 argc, const void *args) {
+s32 attr_public plugin_load(s32 argc, const char* argv[]) {
     final_printf("[GoldHEN] <%s\\Ver.0x%08x> %s\n", g_pluginName, g_pluginVersion, __func__);
     final_printf("[GoldHEN] Plugin Author(s): %s\n", g_pluginAuth);
     boot_ver();
@@ -78,7 +78,7 @@ s32 attr_module_hidden module_start(s64 argc, const void *args) {
     return 0;
 }
 
-s32 attr_module_hidden module_stop(s64 argc, const void *args) {
+s32 attr_public plugin_unload(s32 argc, const char* argv[]) {
     final_printf("[GoldHEN] <%s\\Ver.0x%08x> %s\n", g_pluginName, g_pluginVersion, __func__);
     UNHOOK(sceScreenShotSetOverlayImage);
     UNHOOK(sceScreenShotSetOverlayImageWithOrigin);
@@ -86,5 +86,15 @@ s32 attr_module_hidden module_stop(s64 argc, const void *args) {
     UNHOOK(sceScreenShotDisable);
     UNHOOK(sceRemoteplayProhibit);
     UNHOOK(sceRemoteplayProhibitStreaming);
+    return 0;
+}
+
+s32 attr_module_hidden module_start(s64 argc, const void *args)
+{
+    return 0;
+}
+
+s32 attr_module_hidden module_stop(s64 argc, const void *args)
+{
     return 0;
 }

--- a/plugin_src/plugin_loader/Makefile
+++ b/plugin_src/plugin_loader/Makefile
@@ -1,12 +1,8 @@
 # Library metadata.
 
 DEBUG_FLAGS = -D__FINAL__=1
-LOG_TYPE = -D__USE_KLOG__
+LOG_TYPE = -D__USE_PRINTF__
 BUILD_TYPE = _final
-
-ifeq ($(PRINTF),1)
-    LOG_TYPE = -D__USE_PRINTF__
-endif
 
 ifeq ($(DEBUG),1)
     DEBUG_FLAGS = -D__FINAL__=0
@@ -22,7 +18,7 @@ TARGET_ELF   := $(BUILD_FOLDER)/elf$(TYPE)/$(OUTPUT_PRX)
 TARGETSTUB   := $(OUTPUT_PRX).so
 
 # Libraries linked into the ELF.
-LIBS := -lGoldHEN_Hook -lkernel -lSceLibcInternal -lSceSysmodule
+LIBS := -lSceLibcInternal -lGoldHEN_Hook -lkernel -lSceSysmodule
 
 EXTRAFLAGS := $(DEBUG_FLAGS) $(LOG_TYPE) -fcolor-diagnostics -Wall
 

--- a/plugin_src/plugin_template/Makefile
+++ b/plugin_src/plugin_template/Makefile
@@ -1,12 +1,8 @@
 # Library metadata.
 
 DEBUG_FLAGS = -D__FINAL__=1
-LOG_TYPE = -D__USE_KLOG__
+LOG_TYPE = -D__USE_PRINTF__
 BUILD_TYPE = _final
-
-ifeq ($(PRINTF),1)
-    LOG_TYPE = -D__USE_PRINTF__
-endif
 
 ifeq ($(DEBUG),1)
     DEBUG_FLAGS = -D__FINAL__=0
@@ -22,7 +18,7 @@ TARGET_ELF   := $(BUILD_FOLDER)/elf$(TYPE)/$(OUTPUT_PRX)
 TARGETSTUB   := $(OUTPUT_PRX).so
 
 # Libraries linked into the ELF.
-LIBS := -lGoldHEN_Hook -lkernel -lSceLibcInternal -lSceSysmodule
+LIBS := -lSceLibcInternal -lGoldHEN_Hook -lkernel -lSceSysmodule
 
 EXTRAFLAGS := $(DEBUG_FLAGS) $(LOG_TYPE) -fcolor-diagnostics -Wall
 

--- a/plugin_src/plugin_template/source/main.c
+++ b/plugin_src/plugin_template/source/main.c
@@ -9,16 +9,28 @@ attr_public const char *g_pluginDesc = "Example Plugin";
 attr_public const char *g_pluginAuth = "(null)";
 attr_public uint32_t g_pluginVersion = 0x00000100; // 1.00
 
-int32_t attr_module_hidden module_start(size_t argc, const void *args) {
+int32_t attr_public plugin_load(int32_t argc, const char* argv[]) {
     final_printf("[GoldHEN] %s Plugin Started.\n", g_pluginName);
     final_printf("[GoldHEN] <%s\\Ver.0x%08x> %s\n", g_pluginName, g_pluginVersion, __func__);
     final_printf("[GoldHEN] Plugin Author(s): %s\n", g_pluginAuth);
-    Notify(TEX_ICON_SYSTEM, "Hello from %s", g_pluginName);
+    char msg[128] = {0};
+    snprintf(msg, sizeof(msg),  "Hello from %s", g_pluginName);
+    NotifyStatic(TEX_ICON_SYSTEM, msg);
     return 0;
 }
 
-int32_t attr_module_hidden module_stop(size_t argc, const void *args) {
+int32_t attr_public plugin_unload(int32_t argc, const char* argv[]) {
     final_printf("[GoldHEN] <%s\\Ver.0x%08x> %s\n", g_pluginName, g_pluginVersion, __func__);
     final_printf("[GoldHEN] %s Plugin Ended.\n", g_pluginName);
+    return 0;
+}
+
+s32 attr_module_hidden module_start(s64 argc, const void *args)
+{
+    return 0;
+}
+
+s32 attr_module_hidden module_stop(s64 argc, const void *args)
+{
     return 0;
 }


### PR DESCRIPTION
This might be controversial but to parse module info for UI, we'd need to use `sceKernelLoadStartModule` to retrieve exported symbol information but it would also run `module_start` due to how we defined it in the crtprx in the SDK.

With the exception of the loader. We don't ship these in release builds and to run the loader `module_start` is required at least without changes from GoldHEN internal loader.

**This will break compatibility with built in loader in GoldHEN 2.3.**